### PR TITLE
Now can build with or without pthread hook, with or without druntime

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -9,16 +9,43 @@
 	"name": "symgc",
 	"configurations" : {
 		"standard" : {
-			"targetType": "library"
+			"targetType": "library",
+			"versions": [
+				"Symgc_druntime_hooks"
+			]
+		},
+		"legacy" : {
+			"targetType": "library",
+			"versions" : [
+				"Symgc_pthread_hook",
+				"Symgc_druntime_hooks"
+			]
+		},
+		"pthread" : {
+			"targetType": "library",
+			"versions" : [
+				"Symgc_pthread_hook"
+			]
 		},
 		"integration" : {
 			"targetType": "library",
-			"versions" : ["integrationTests"]
+			"versions" : [
+				"Symgc_pthread_hook"
+			]
 		}
 	},
 	"buildTypes" : {
 		"unittest-x" : {
-			"buildOptions": ["unittests", "releaseMode", "optimize", "inline"]
+			"buildOptions": ["unittests", "releaseMode", "optimize", "inline"],
+			"versions" : [
+				"Symgc_testing"
+			]
+		},
+		"unittest" : {
+			"buildOptions": ["unittests", "debugMode", "debugInfo"],
+			"versions" : [
+				"Symgc_testing"
+			]
 		}
 	}
 }

--- a/source/core/thread/symthread.d
+++ b/source/core/thread/symthread.d
@@ -1,0 +1,135 @@
+// we have to put this in the core.thread package to access thread package internals
+module core.thread.symthread;
+import core.thread.osthread;
+import core.thread.threadbase;
+import core.thread.types;
+import d.gc.types;
+
+private {
+    import core.internal.traits : externDFunc;
+    alias DruntimeScanDg = void delegate(void* pstart, void* pend) nothrow;
+    alias rt_tlsgc_scan =
+        externDFunc!("rt.tlsgc.scan", void function(void*, scope DruntimeScanDg) nothrow);
+}
+
+private Thread toThread(return scope ThreadBase t) @trusted nothrow @nogc pure
+{
+    return cast(Thread) cast(void*) t;
+}
+
+bool suspendDruntimeThreads(bool alwaysSignal, ref uint suspended) {
+	import d.gc.tcache;
+	import d.gc.tstate;
+	Thread t = ThreadBase.sm_tbeg.toThread;
+	auto self = Thread.getThis;
+
+	suspended = 0;
+	bool retry = false;
+
+	while (t)
+	{
+		auto tn = t.next.toThread;
+		scope(exit) t = tn;
+		if (!t.isRunning)
+		{
+			Thread.remove(t);
+			continue;
+		}
+
+		// skip current thread, we don't need to suspend it.
+		if (t is self) {
+			continue;
+		}
+
+		auto tc = cast(ThreadCache*) t.tlsGCData();
+		// determine if this thread is suspended or should be suspended.
+		if (tc !is null) {
+			auto ss = tc.suspendState;
+
+			suspended += ss == SuspendState.Suspended;
+			retry |= ss != SuspendState.Suspended;
+
+			if (ss != SuspendState.None)
+				continue;
+
+			import d.gc.signal;
+			signalThreadSuspend(tc);
+		}
+		else {
+			retry = true;
+			if(alwaysSignal) {
+				// send the signal directly, this is the first time through the
+				// loop. The thread signal handler will register the
+				// threadcache data for subsequent collections and loops
+				import d.gc.signal;
+				import core.sys.posix.pthread;
+				pthread_kill(t.m_addr, SIGSUSPEND);
+			}
+		}
+	}
+
+	// suspend all the threads that are not us, but also record that we suspended "ourself"
+	suspendDepth = suspended + 1;
+	return retry;
+}
+
+void scanWorldPausedData(ScanDg scan) {
+	// scan all data that is NOT part of our thread's current stack.
+	auto myStackBottom = Thread.getThis().m_curr.bstack;
+	void scanItem(ScanType type, void* pbot, void* ptop) nothrow {
+		import d.gc.range;
+		auto r = makeRange(pbot, ptop);
+		if (type == ScanType.stack && myStackBottom >= r.ptr &&
+				myStackBottom <= r.ptr + r.length)
+			// my stack range, no need to scan right now, this will be scanned later
+			return;
+		// TODO: ignore my thread's TLS data as well.
+		// TODO: shouldn't need this cast
+		alias NoThrowScanDg = void delegate(const(void*)[] range) nothrow;
+		(cast(NoThrowScanDg)scan)(r);
+	}
+
+	thread_scanAllType(&scanItem);
+}
+
+bool resumeDruntimeThreads(ref uint suspended) {
+	import d.gc.tcache;
+	import d.gc.tstate;
+	Thread t = ThreadBase.sm_tbeg.toThread;
+
+	suspended = 0;
+	bool retry = false;
+
+	while (t)
+	{
+		auto tn = t.next.toThread;
+		scope(exit) t = tn;
+		if (!t.isRunning)
+		{
+			Thread.remove(t);
+			continue;
+		}
+
+		auto tc = cast(ThreadCache*) t.tlsGCData();
+		// determine if this thread is suspended or should be suspended.
+		if (tc is null) {
+			// if the threadcache is null, this means we didn't suspend it. skip it.
+			continue;
+		}
+
+		auto ss = tc.suspendState;
+
+		suspended += ss == SuspendState.Suspended;
+		retry |= ss != SuspendState.None;
+
+		if (ss != SuspendState.Suspended)
+			continue;
+
+		import d.gc.signal;
+		signalThreadResume(tc);
+	}
+
+	// update the suspended count
+	suspendDepth = suspended;
+	return retry;
+}

--- a/source/d/gc/range.d
+++ b/source/d/gc/range.d
@@ -7,7 +7,7 @@ import d.gc.spec;
  * This function get a void[] range and chnage it into a
  * const(void*)[] one, reducing to alignement boundaries.
  */
-const(void*)[] makeRange(const void[] range) {
+const(void*)[] makeRange(const void[] range) nothrow {
 	auto begin = alignUp(range.ptr, PointerSize);
 	auto end = alignDown(range.ptr + range.length, PointerSize);
 
@@ -23,7 +23,7 @@ const(void*)[] makeRange(const void[] range) {
 	return ptr[0 .. length];
 }
 
-const(void*)[] makeRange(const void* start, const void* stop) {
+const(void*)[] makeRange(const void* start, const void* stop) nothrow {
 	auto length = stop - start;
 	return makeRange(start[0 .. length]);
 }

--- a/source/d/gc/stack.d
+++ b/source/d/gc/stack.d
@@ -20,6 +20,17 @@ struct ThreadScanner {
 	void scanStack(void* top) {
 		import d.gc.tcache;
 		auto bottom = threadCache.stackBottom;
+		version(Symgc_druntime_hooks) {
+			// TODO: need to look up Thread.getThis() twice, because there is
+			// no public way to get the stack bottom from a thread instance,
+			// and if we try to call thread_stackBottom() blindly, a null
+			// current thread pointer could trigger a segfault.
+			import core.thread;
+			if (Thread.getThis() !is null) {
+				bottom = thread_stackBottom();
+			}
+			assert(bottom !is null, "Null stack bottom!");
+		}
 
 		import d.gc.range;
 		scan(makeRange(top, bottom));

--- a/source/d/gc/util.d
+++ b/source/d/gc/util.d
@@ -1,5 +1,7 @@
 module d.gc.util;
 
+nothrow:
+
 T min(T)(T a, T b) {
 	return a <= b ? a : b;
 }

--- a/source/symgc/gcobj.d
+++ b/source/symgc/gcobj.d
@@ -6,6 +6,11 @@ static import core.memory;
 
 import core.stdc.string : memset;
 
+// when running unittests and druntime is involved, set the GC to the symmetry GC
+version(Symgc_testing) version(Symgc_druntime_hooks) {
+	extern(C) __gshared rt_options = ["gcopt=gc:sdc"];
+}
+
 extern(C) nothrow {
 	void onOutOfMemoryError(void* pretend_sideffect = null, string file = __FILE__, size_t line = __LINE__) @trusted nothrow @nogc;
 

--- a/source/symgc/trampoline.d
+++ b/source/symgc/trampoline.d
@@ -7,23 +7,25 @@ import core.sys.posix.pthread;
 
 alias PthreadFunction = extern(C) void* function(void*);
 
-// Hijack the system's pthread_create function so we can register the thread.
-extern(C) int pthread_create(pthread_t* thread, scope const pthread_attr_t* attr,
-                             PthreadFunction start_routine, void* arg) {
-	auto runner = ThreadRunner.alloc(start_routine, arg);
+version(Symgc_pthread_hook) {
+	// Hijack the system's pthread_create function so we can register the thread.
+	extern(C) int pthread_create(pthread_t* thread, scope const pthread_attr_t* attr,
+			PthreadFunction start_routine, void* arg) {
+		auto runner = ThreadRunner.alloc(start_routine, arg);
 
-	// Stop the world cannot happen during thread startup.
-	preventStopTheWorld();
+		// Stop the world cannot happen during thread startup.
+		preventStopTheWorld();
 
-	auto ret =
-		pthread_create_trampoline(thread, attr,
-		                          cast(PthreadFunction) &runThread!true, runner);
-	if (ret != 0) {
-		// The spawned thread will call this when there are no errors.
-		allowStopTheWorld();
+		auto ret =
+			pthread_create_trampoline(thread, attr,
+					cast(PthreadFunction) &runThread!true, runner);
+		if (ret != 0) {
+			// The spawned thread will call this when there are no errors.
+			allowStopTheWorld();
+		}
+
+		return ret;
 	}
-
-	return ret;
 }
 
 /**
@@ -67,37 +69,42 @@ extern(C) void* runThread(bool AllowStopTheWorld)(ThreadRunner* runner) {
 	return fun(arg);
 }
 
-alias PthreadCreateType = typeof(&core.sys.posix.pthread.pthread_create);
+version(Symgc_pthread_hook) {
+	alias PthreadCreateType = typeof(&core.sys.posix.pthread.pthread_create);
 
-__gshared
-PthreadCreateType pthread_create_trampoline = cast(PthreadCreateType)&resolve_pthread_create;
+	__gshared
+		PthreadCreateType pthread_create_trampoline = cast(PthreadCreateType)&resolve_pthread_create;
 
-extern(C) int resolve_pthread_create(pthread_t* thread, scope const pthread_attr_t* attr,
-                           PthreadFunction start_routine, void* arg) {
-	PthreadCreateType real_pthread_create;
+	extern(C) int resolve_pthread_create(pthread_t* thread, scope const pthread_attr_t* attr,
+			PthreadFunction start_routine, void* arg) {
+		PthreadCreateType real_pthread_create;
 
-	// First, check if there is an interceptor and if so, use it.
-	// This ensure we remain compatible with sanitizers, as they use
-	// a similar trick to intercept various library calls.
-	import core.sys.linux.dlfcn;
-	real_pthread_create = cast(PthreadCreateType)
-		dlsym(RTLD_DEFAULT, "__interceptor_pthread_create");
-	if (real_pthread_create !is null) {
-		goto Forward;
-	}
+		// First, check if there is an interceptor and if so, use it.
+		// This ensure we remain compatible with sanitizers, as they use
+		// a similar trick to intercept various library calls.
+		import core.sys.linux.dlfcn;
+		real_pthread_create = cast(PthreadCreateType)
+			dlsym(RTLD_DEFAULT, "__interceptor_pthread_create");
+		if (real_pthread_create !is null) {
+			goto Forward;
+		}
 
-	// It doesn't look like we have an interceptor, forward to the method
-	// in the next object.
-	real_pthread_create =
-		cast(PthreadCreateType) dlsym(RTLD_NEXT, "pthread_create");
-	if (real_pthread_create is null) {
-		import core.stdc.stdlib, core.stdc.stdio;
-		printf("Failed to locate pthread_create!");
-		exit(1);
-	}
+		// It doesn't look like we have an interceptor, forward to the method
+		// in the next object.
+		real_pthread_create =
+			cast(PthreadCreateType) dlsym(RTLD_NEXT, "pthread_create");
+		if (real_pthread_create is null) {
+			import core.stdc.stdlib, core.stdc.stdio;
+			printf("Failed to locate pthread_create!");
+			exit(1);
+		}
 
 Forward:
-	// Rebind the trampoline so we never resolve again.
-	pthread_create_trampoline = real_pthread_create;
-	return real_pthread_create(thread, attr, start_routine, arg);
+		// Rebind the trampoline so we never resolve again.
+		pthread_create_trampoline = real_pthread_create;
+		return real_pthread_create(thread, attr, start_routine, arg);
+	}
+} else {
+	// no trampoline used
+	alias pthread_create_trampoline = pthread_create;
 }


### PR DESCRIPTION
hooks. All 3 modes of pthread, druntime, and pthread+druntime pass unittests. Integration tests still only pass with pthread mode, but that likely will not be changed. Instead we will add tests for druntime.