### PR TITLE
Do not use global space to store arenas, use an allocated block, which

### DIFF
--- a/source/d/gc/thread.d
+++ b/source/d/gc/thread.d
@@ -6,6 +6,10 @@ import d.gc.tstate;
 import d.gc.types;
 
 void createProcess() {
+	import d.gc.base;
+	import d.gc.arena;
+	Arena.initializeArenaStorage(gBase);
+
 	enterBusyState();
 	scope(exit) exitBusyState();
 


### PR DESCRIPTION
must be initialized on program start.

This eliminates 7MB of space that is scanned on every GC cycle (even with the original GC) which will never have any valid pointers in it.

If in the future, we can segregate glboals into scannable storage and non-scannable storage, then perhaps this change can be modified to avoid requiring initializing the arena storage.