### PR TITLE
Change RTree storage of nodes to use an external allocation instead

### DIFF
--- a/source/d/gc/arena.d
+++ b/source/d/gc/arena.d
@@ -231,6 +231,7 @@ package:
 
 	import d.gc.emap;
 	static shared ExtentMap emapStorage;
+	emapStorage.initialize(*base);
 	auto emap = CachedExtentMap(&emapStorage, base);
 
 	import d.gc.region;
@@ -312,6 +313,7 @@ package:
 
 	import d.gc.emap;
 	static shared ExtentMap emapStorage;
+	emapStorage.initialize(*base);
 	auto emap = CachedExtentMap(&emapStorage, base);
 
 	import d.gc.region;
@@ -474,6 +476,7 @@ package:
 
 	import d.gc.emap;
 	static shared ExtentMap emapStorage;
+	emapStorage.initialize(*base);
 	auto emap = CachedExtentMap(&emapStorage, base);
 
 	import d.gc.region;

--- a/source/d/gc/emap.d
+++ b/source/d/gc/emap.d
@@ -35,6 +35,10 @@ public:
 	void clear(ref ExtentMapCache cache, void* address, uint pages) shared {
 		tree.clearRange(cache, address, pages);
 	}
+
+	void initialize(ref shared(Base) base) shared {
+		tree.initialize(base);
+	}
 }
 
 /**
@@ -233,6 +237,7 @@ public:
 	scope(exit) base.clear();
 
 	static shared ExtentMap emapStorage;
+	emapStorage.initialize(base);
 	auto emap = CachedExtentMap(&emapStorage, &base);
 
 	// We have not mapped anything.

--- a/source/d/gc/rtree.d
+++ b/source/d/gc/rtree.d
@@ -37,7 +37,12 @@ static assert((Level0Mask & BlockPointerMask) == 0,
 
 struct RTree(T) {
 private:
-	Node[Level0Size] nodes;
+	Node[Level0Size]* _nodeStorage;
+
+	@property
+	ref shared(Node[Level0Size]) nodes() shared {
+		return *_nodeStorage;
+	}
 
 	import d.sync.mutex;
 	Mutex initMutex;
@@ -189,6 +194,13 @@ public:
 				ptr += PageSize;
 			}
 		}
+	}
+
+	void initialize(ref shared Base base) shared {
+		// allocate the nodes for use. This must be called before any other
+		// methods are used.
+		_nodeStorage = cast(typeof(_nodeStorage))
+			base.reserveAddressSpace(typeof(*_nodeStorage).sizeof);
 	}
 
 private:
@@ -411,6 +423,7 @@ static subKey(void* ptr, uint level) {
 	scope(exit) base.clear();
 
 	static shared RTree!ulong rt;
+	rt.initialize(base);
 	RTreeCache!ulong cache;
 
 	auto p = cast(void*) 0x56789abcd000;
@@ -440,6 +453,7 @@ static subKey(void* ptr, uint level) {
 	scope(exit) base.clear();
 
 	static shared RTree!ulong rt;
+	rt.initialize(base);
 	RTreeCache!ulong cache;
 
 	// Add one page descriptor in the tree.
@@ -491,6 +505,7 @@ static subKey(void* ptr, uint level) {
 	scope(exit) base.clear();
 
 	static shared RTree!ulong rt;
+	rt.initialize(base);
 	RTreeCache!ulong cache;
 
 	// Add one page descriptor in the tree.
@@ -556,6 +571,7 @@ static subKey(void* ptr, uint level) {
 	scope(exit) base.clear();
 
 	static shared RTree!ulong rt;
+	rt.initialize(base);
 	RTreeCache!ulong cache;
 
 	enum L1Size = RTreeCache!ulong.L1Size;

--- a/source/d/gc/tbin.d
+++ b/source/d/gc/tbin.d
@@ -605,6 +605,7 @@ uint computeThreadCacheSize() {
 
 	import d.gc.emap;
 	static shared ExtentMap emapStorage;
+	emapStorage.initialize(*base);
 	auto emap = CachedExtentMap(&emapStorage, base);
 
 	import d.gc.region;
@@ -745,6 +746,7 @@ uint computeThreadCacheSize() {
 
 	import d.gc.emap;
 	static shared ExtentMap emapStorage;
+	emapStorage.initialize(*base);
 	auto emap = CachedExtentMap(&emapStorage, base);
 
 	import d.gc.region;

--- a/source/d/gc/thread.d
+++ b/source/d/gc/thread.d
@@ -6,6 +6,10 @@ import d.gc.tstate;
 import d.gc.types;
 
 void createProcess() {
+	import d.gc.emap;
+	import d.gc.base;
+	gExtentMap.initialize(gBase);
+
 	enterBusyState();
 	scope(exit) exitBusyState();
 


### PR DESCRIPTION
global storage. This reduces the amount of data needed to scan in both original GC and new GC.