### PR TITLE
Remove register_default_gcs() override

### DIFF
--- a/source/symgc/gcobj.d
+++ b/source/symgc/gcobj.d
@@ -91,29 +91,6 @@ extern(C) void _d_register_sdc_gc()
 	}
 }
 
-shared static this()
-{
-	register_default_gcs();
-}
-
-extern(C) {
-	// do not import GC modules, they might add a dependency to this whole module
-	void _d_register_conservative_gc();
-	void _d_register_manual_gc();
-
-	// overtakes the function in core.internal.gc.
-	void* register_default_gcs()
-	{
-		pragma(inline, false);
-		// do not call, they register implicitly through pragma(crt_constructor)
-		// avoid being optimized away
-		auto reg1 = &_d_register_conservative_gc;
-		auto reg2 = &_d_register_manual_gc;
-		auto reg3 = &_d_register_sdc_gc;
-		return reg1 < reg2 ? reg1 : reg2 < reg3 ? reg2 : reg3;
-	}
-}
-
 
 // since all the real work is done in the SDC library, the class is just a
 // shim, and can just be initialized at compile time.


### PR DESCRIPTION
As it doesn't work as expected anyway, not magically dragging in symgc into the build - the object file needs to be linked for the strong symbol to override druntime's weak default one. And linking the object file is enough to register the GC anyway, due to the CRT constructor.

Additionally, the strong symbol means that an app cannot define its own, or link another alternative GC which also provides such a strong symbol. This e.g. causes a druntime integration test to fail (which overrides `register_default_gcs()` too, and the linker then errors out with 2 conflicting strong symbols), when integrating symgc into druntime.