### PR TITLE
Fix race condition on windows, where we might suspend a thread that

### DIFF
--- a/source/core/thread/symthread.d
+++ b/source/core/thread/symthread.d
@@ -123,11 +123,13 @@ bool suspendDruntimeThreads(bool alwaysSignal, ref uint suspended) {
 					continue;
 				}
 
-				// Could not suspend, handle a delayed suspend
+				// delayed, resume the thread, and increment the delayed thread count.
+				// IMPORTANT: We must FIRST resume the thread, as it may hold
+				// the lock that we need to increment the delayed count.
+				core_thread_osthread_resume(t);
 				import d.gc.thread : delayedThreadInc;
 				delayedThreadInc();
-				// delayed, resume the thread, and increment the delayed thread count.
-				core_thread_osthread_resume(t);
+
 				retry = true;
 			}
 		}

--- a/source/d/gc/thread.d
+++ b/source/d/gc/thread.d
@@ -165,7 +165,7 @@ private:
 
 	uint registeredThreadCount = 0;
 	uint suspendedThreadCount = 0;
-	uint delayedThreadCount = 0;
+	int delayedThreadCount = 0;
 
 	Mutex mThreadList;
 	ThreadRing registeredThreads;


### PR DESCRIPTION
holds a lock we need, and then try to lock that lock before resuming it.