### PR TITLE
Get scan threads started before stopping the world

### DIFF
--- a/source/d/gc/collector.d
+++ b/source/d/gc/collector.d
@@ -55,11 +55,10 @@ private:
 		}
 
 		import symgc.thread;
-		auto threads = (cast(ThreadHandle*)threadCache.alloc(ThreadHandle.sizeof * (threadCount - 1), false, false))[0 .. threadCount];
+		auto nScanningThreads = threadCount - 1;
+		auto threads = (cast(ThreadHandle*)threadCache.alloc(ThreadHandle.sizeof * nScanningThreads, false, false))[0 .. nScanningThreads];
 		scanner.startThreads(threads);
 
-		import core.thread;
-		//Thread.sleep(20.msecs);
 		import d.gc.thread;
 		stopTheWorld();
 

--- a/source/d/gc/scanner.d
+++ b/source/d/gc/scanner.d
@@ -264,7 +264,11 @@ public:
 			threadCache.activateGC(false);
 
 			auto scanner = cast(shared(Scanner)*) ctx;
-			// This holds off the spawned threads until the GC is ready to run.
+			// Deferring becoming active until the thread is fully started
+			// allows the scan to complete if this thread couldn't start (which
+			// can happen in the case of a race between the thread starting and
+			// a paused thread holding a critical lock needed to start
+			// threads).
 			scanner.work.scanThreadStarted();
 			scanner.runMark();
 		}

--- a/source/d/gc/scanner.d
+++ b/source/d/gc/scanner.d
@@ -29,6 +29,7 @@ private struct ScanningList {
 		void initialize() {
 			_spinlock = SpinLock(SpinLock.Contention.brief);
 			workReadyEvent.initialize(true, false);
+			this.activeThreads = 1;
 		}
 
 		void addToWorkList(WorkItem[] items) shared {
@@ -42,6 +43,15 @@ private struct ScanningList {
 
 		// Note: SpinLock does not provide this information, even though it could.
 		bool mutexIsHeld() => true;
+
+		void scanThreadStarted() shared {
+			auto w = (cast(ScanningList*) &this);
+
+			_spinlock.lock();
+			scope(exit) _spinlock.unlock();
+
+			++w.activeThreads;
+		}
 
 		uint waitForWork(ref WorkItem[MaxRefill] refill) shared {
 			_spinlock.lock();
@@ -58,10 +68,9 @@ private struct ScanningList {
 			* of active thread is 0, then we know no more work is coming
 			* and we should stop.
 			*/
-			while(w.cursor == 0 && w.activeThreads > 0) {
+			while(!w.hasWork()) {
 				w.workReadyEvent.reset();
 				_spinlock.unlock();
-				import core.time;
 				w.workReadyEvent.wait();
 				_spinlock.lock();
 			}
@@ -105,11 +114,7 @@ private struct ScanningList {
 		import d.sync.mutex;
 		Mutex _mutex;
 		void initialize() {
-			// no-op
-		}
-
-		auto hasWork() {
-			return cursor != 0 || activeThreads == 0;
+			this.activeThreads = 1;
 		}
 
 		bool mutexIsHeld() => _mutex.isHeld();
@@ -119,6 +124,14 @@ private struct ScanningList {
 			scope(exit) _mutex.unlock();
 
 			(cast(ScanningList*) &this).addToWorkListImpl(items);
+		}
+
+		void scanThreadStarted() shared {
+			mutex.lock();
+			scope(exit) mutex.unlock();
+
+			// ready to receive scan work.
+			++activeThreads;
 		}
 
 		uint waitForWork(ref WorkItem[MaxRefill] refill) shared {
@@ -166,6 +179,10 @@ private struct ScanningList {
 			w.cursor = top - count;
 			return count;
 		}
+	}
+
+	auto hasWork() {
+		return cursor != 0 || activeThreads == 0;
 	}
 
 	void ensureWorklistCapacity(size_t count) {
@@ -219,26 +236,12 @@ struct Scanner {
 private:
 	ScanningList work;
 
-
 	ubyte _gcCycle;
 	AddressRange _managedAddressSpace;
 
 public:
-	this(uint threadCount, ubyte gcCycle, AddressRange managedAddressSpace) {
-		if (threadCount == 0) {
-			import d.gc.cpu;
-			threadCount = getCoreCount();
-			assert(threadCount >= 1, "Expected at least one thread!");
-		}
-
-		work.activeThreads = threadCount;
-
+	this(ubyte gcCycle) {
 		this._gcCycle = gcCycle;
-		this._managedAddressSpace = managedAddressSpace;
-	}
-
-	this(ubyte gcCycle, AddressRange managedAddressSpace) {
-		this(0, gcCycle, managedAddressSpace);
 	}
 
 	@property
@@ -251,47 +254,45 @@ public:
 		return (cast(Scanner*) &this)._gcCycle;
 	}
 
-	void mark() shared {
-		(cast(Scanner*)&this).work.initialize();
-		import symgc.thread;
-		auto threadCount = work.activeThreads - 1;
-		import core.stdc.stdlib : alloca;
-		auto threadsPtr =
-			cast(ThreadHandle*) alloca(ThreadHandle.sizeof * threadCount);
-		auto threads = threadsPtr[0 .. threadCount];
-
+	private import symgc.thread;
+	void startThreads(ThreadHandle[] threads) {
+		work.initialize();
 		static void markThreadEntry(void* ctx) {
 			import d.gc.tcache;
 			threadCache.activateGC(false);
 
-			(cast(shared(Scanner*)) ctx).runMark();
+			auto scanner = cast(shared(Scanner)*) ctx;
+			// This holds off the spawned threads until the GC is ready to run.
+			scanner.work.scanThreadStarted();
+			scanner.runMark();
 		}
 
-		// First thing, start the worker threads, so they can do work ASAP.
 		foreach (ref tid; threads) {
 			createGCThread(&tid, &markThreadEntry, cast(void*) &this);
 		}
+	}
+
+	void joinThreads(ThreadHandle[] threads) shared {
+		foreach (tid; threads) {
+			joinGCThread(tid);
+		}
+
+		work.cleanup();
+	}
+
+	void mark(AddressRange managedSpace) shared {
+		this._managedAddressSpace = managedSpace;
 
 		// Scan the roots.
 		// TODO: this cast is awful, see if we can fix this.
 		__sd_gc_global_scan(cast(void delegate(const(void*)[]))&processGlobal);
 
 		// Now send this thread marking!
-		runMark();
-
-		work.cleanup();
-
-		foreach (tid; threads) {
-			joinGCThread(tid);
-		}
+		runMarkFromMainThread();
 	}
 
 	void addToWorkList(WorkItem item) shared {
 		work.addToWorkList((&item)[0 .. 1]);
-	}
-
-	void addToWorkList(WorkItem[] items) shared {
-		work.addToWorkList(items);
 	}
 
 	void processGlobal(const(void*)[] range) shared {
@@ -319,9 +320,20 @@ public:
 	}
 
 private:
+
+	void runMarkFromMainThread() shared {
+		auto worker = Worker(&this);
+		import d.gc.thread;
+		threadScan(&worker.scan);
+
+		runMarkImpl(worker);
+	}
 	void runMark() shared {
 		auto worker = Worker(&this);
+		runMarkImpl(worker);
+	}
 
+	void runMarkImpl(ref Worker worker) shared {
 		/**
 		 * Scan the stack and TLS.
 		 *
@@ -335,13 +347,20 @@ private:
 		 * and corrupting the internal of the standard C library.
 		 *
 		 * This is NOT good! So we scan here to make sure we don't miss anything.
+		 *
+		 * Note: this is only relevant if the C malloc calls are replaced with the
+		 * GC allocation calls which is not a thing we can do universally. Since
+		 * this prospect is dicey, there is no reason to do this, and this allows
+		 * us to avoid an extra startup sync.
 		 */
-		import d.gc.thread;
-		threadScan(&worker.scan);
+		// import d.gc.thread;
+		// threadScan(&worker.scan);
 
 		WorkItem[ScanningList.MaxRefill] refill;
+		auto count = work.waitForWork(refill);
+		// had to wait until now to be sure the managed address space is correct
+		worker.managedAddressSpace = managedAddressSpace;
 		while (true) {
-			auto count = work.waitForWork(refill);
 			if (count == 0) {
 				// We are done, there is no more work items.
 				return;
@@ -350,6 +369,7 @@ private:
 			foreach (i; 0 .. count) {
 				worker.scan(refill[i]);
 			}
+			count = work.waitForWork(refill);
 		}
 	}
 }
@@ -470,7 +490,7 @@ public:
 						continue;
 					}
 
-					scanner.addToWorkList(worklist[0 .. WorkListCapacity]);
+					scanner.work.addToWorkList(worklist[0 .. WorkListCapacity]);
 
 					cursor = 1;
 					worklist[0] = i;

--- a/source/d/gc/scanner.d
+++ b/source/d/gc/scanner.d
@@ -127,11 +127,13 @@ private struct ScanningList {
 		}
 
 		void scanThreadStarted() shared {
-			mutex.lock();
-			scope(exit) mutex.unlock();
+			auto w = (cast(ScanningList*) &this);
+
+			_mutex.lock();
+			scope(exit) _mutex.unlock();
 
 			// ready to receive scan work.
-			++activeThreads;
+			++w.activeThreads;
 		}
 
 		uint waitForWork(ref WorkItem[MaxRefill] refill) shared {

--- a/source/d/gc/thread.d
+++ b/source/d/gc/thread.d
@@ -33,21 +33,28 @@ void createProcess() {
 	}
 }
 
-void createThread(bool AllowStopTheWorld)() {
+void createThread(bool BackgroundThread)() {
 	enterBusyState();
 	scope(exit) {
-		if (AllowStopTheWorld) {
+		if (!BackgroundThread) {
 			allowStopTheWorld();
 		}
 
 		exitBusyState();
 	}
 
+	if(BackgroundThread) {
+		// make sure this thread is not paused for scanning.
+		threadCache.state.preventPausing();
+	}
+
 	initThread();
 
 	version(Symgc_pthread_hook) {
-		import symgc.rt;
-		registerTlsSegments();
+		if(!BackgroundThread) {
+			import symgc.rt;
+			registerTlsSegments();
+		}
 	}
 }
 

--- a/source/d/gc/tstate.d
+++ b/source/d/gc/tstate.d
@@ -82,6 +82,20 @@ public:
 		}
 	}
 
+	void preventPausing() {
+		auto s = state.load();
+		while (true) {
+			auto n = s + SuspendState.Detached;
+
+			assert(status(s) == SuspendState.None);
+			assert(status(n) == SuspendState.Detached);
+
+			if (state.casWeak(s, n)) {
+				break;
+			}
+		}
+	}
+
 	bool onSuspendSignal() {
 		auto s = state.load();
 

--- a/source/symgc/trampoline.d
+++ b/source/symgc/trampoline.d
@@ -22,7 +22,7 @@ extern(C) int pthread_create(pthread_t* thread, scope const pthread_attr_t* attr
 
 	auto ret =
 		pthread_create_trampoline(thread, attr,
-				cast(PthreadFunction) runner.getFunction!true(), runner);
+				cast(PthreadFunction) runner.getFunction!false(), runner);
 	if (ret != 0) {
 		// The spawned thread will call this when there are no errors.
 		allowStopTheWorld();


### PR DESCRIPTION
This prevents a hang where thread startup or thread shutdown requires library thread locks that might be held by paused threads.

This is a delicate situation, it requires that we start our scan threads AND start the GC setup process simultaneously. During scan thread startup:

1. No scan thread can alllocate (this is why with the pthread hook, we skip registration of TLS segments, these don't need to be scanned anyway)
2. The thread must not be paused (hence the new `preventPause` function)
3. Any scan thread that might be held up due to system thread startup does not stop the GC from running. This is a race between threads completing their initial setup, and threads being paused while holding necessary locks.

item 3 means that some scan threads may not participate in the scan. This is less than ideal, but the cost of waiting for all the threads to initialize is much higher than skipping a scan thread. This will be mitigated in a further PR, where we just keep the threads always alive as long as we might run a GC (they will get past the initial startup, and then won't be impeded in further scans). This is how druntime does it, and avoids most issues of thread sync.

This is also why we don't start with all scan threads active. If a scan thread can't start, it can't become active, or it will hang the scan (we require active threads == 0 to complete a scan).

The pthread hook is becoming more of a liability, and likely we should just scrap it completely. But I will need to update all the base tests that depend on it. We already do this in Windows...