### PR TITLE
Keep scan threads alive

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The idea is to extract the GC portions of the SDC runtime (and everything needed
 ## Requirements
 
 Intel/AMD 64-bit CPU.
-Linux (so far)
+Linux or Windows (so far)
 
 DMD 2.111 or later
 
@@ -60,6 +60,7 @@ To run, use dub in the test directory.
 - [X] Add object for including new GC into druntime.
 - [X] Test with real projects
 - [X] Remove pthread override, use normal druntime hooks.
+- [X] Detach scan threads from GC start and stop, allow them to be kept for next cycle and beyond.
 
 Note there are 3 configs:
 - `standard` - Uses only druntime hooks for all GC operations. The SDC `pthread_create` trampoline is not used
@@ -70,11 +71,12 @@ All three configs pass unittests (only a couple unittests needed modification to
 
 The integration tests are explicitly using the `pthread` config, as those do not expect to use druntime.
 
+- [X] druntime update to handle thread creation and destruction.
+- [X] Port integration tests to standard config (druntime only).
+- [X] Windows support
+
 ## Todo
 
-- [ ] druntime update to handle thread creation and destruction.
-- [ ] Windows support
-- [ ] Port integration tests to standard config (druntime only).
 - [ ] ARM 64-bit support.
 
 ## Acknowledgements

--- a/source/core/thread/symthread.d
+++ b/source/core/thread/symthread.d
@@ -117,6 +117,7 @@ bool suspendDruntimeThreads(bool alwaysSignal, ref uint suspended) {
 			tc.sendSuspendSignal();
 
 			if (core_thread_osthread_suspend(t)) {
+				tc.checkLockWaiting();
 				if (tc.onSuspendSignal()) {
 					tc.markSuspended();
 					++suspended;
@@ -214,6 +215,7 @@ bool resumeDruntimeThreads(ref uint suspended) {
 			if (ss != SuspendState.Suspended)
 				continue;
 
+			tc.resolveLockWaiting();
 			tc.sendResumeSignal();
 			tc.onResumeSignal();
 		}

--- a/source/d/gc/collector.d
+++ b/source/d/gc/collector.d
@@ -44,7 +44,6 @@ private:
 
 		// set up the scanner
 		import d.gc.scanner;
-		auto scanner = Scanner(gcCycle);
 
 		// start the threads
 		auto threadCount = gCollectorState.scanningThreads;
@@ -56,8 +55,7 @@ private:
 
 		import symgc.thread;
 		auto nScanningThreads = threadCount - 1;
-		auto threads = (cast(ThreadHandle*)threadCache.alloc(ThreadHandle.sizeof * nScanningThreads, false, false))[0 .. nScanningThreads];
-		scanner.startThreads(threads);
+		startGCThreads(nScanningThreads);
 
 		import d.gc.thread;
 		stopTheWorld();
@@ -72,14 +70,9 @@ private:
 		prepareGCCycle();
 
 		// Go on and on until all worklists are empty.
-		(cast(shared(Scanner*))&scanner).mark(managedAddressSpace);
+		markGC(gcCycle, managedAddressSpace);
 
 		restartTheWorld();
-
-		(cast(shared(Scanner*))&scanner).joinThreads(threads);
-
-		// clean up the thread list pointer
-		threadCache.free(threads.ptr);
 
 		/**
 		 * We might have allocated, and therefore refilled the bin

--- a/source/d/gc/scanner.d
+++ b/source/d/gc/scanner.d
@@ -8,13 +8,30 @@ import d.gc.range;
 import d.gc.slab;
 import d.gc.spec;
 import d.gc.util;
+import d.gc.tcache;
 
-private struct ScanningList {
+void startGCThreads(uint nThreads) {
+	(cast(Scanner*)&gScanner).startThreads(nThreads);
+}
+
+void cleanupGCThreads() {
+	(cast(Scanner*)&gScanner).joinThreads();
+}
+
+void markGC(ubyte gcCycle, AddressRange managedSpace) {
+	gScanner.mark(gcCycle, managedSpace);
+}
+
+private:
+struct ScanningList {
 	@disable this(this);
 	WorkItem[] worklist;
-	uint activeThreads;
+	int activeThreads;
 	uint cursor;
 	enum MaxRefill = 4;
+	// we want to use the main thread's tcache when reallocating to avoid populating
+	// the threadcache of all the scanning threads with stuff.
+	ThreadCache* threadCache;
 
 	version(Windows) {
 		// The windows implementation uses a similar mechanism to the druntime GC,
@@ -25,11 +42,13 @@ private struct ScanningList {
 
 		shared SpinLock _spinlock;
 		Event workReadyEvent;
+		Event gcStartedEvent;
 
 		void initialize() {
+			this.threadCache = &.threadCache;
 			_spinlock = SpinLock(SpinLock.Contention.brief);
 			workReadyEvent.initialize(true, false);
-			this.activeThreads = 1;
+			gcStartedEvent.initialize(true, false);
 		}
 
 		void addToWorkList(WorkItem[] items) shared {
@@ -39,18 +58,58 @@ private struct ScanningList {
 			(cast(ScanningList*) &this).addToWorkListImpl(items);
 
 			(cast(Event*)&workReadyEvent).setIfInitialized();
+			(cast(Event*)&gcStartedEvent).setIfInitialized();
 		}
 
 		// Note: SpinLock does not provide this information, even though it could.
 		bool mutexIsHeld() => true;
 
-		void scanThreadStarted() shared {
+		void mainThreadStarted() shared {
 			auto w = (cast(ScanningList*) &this);
 
 			_spinlock.lock();
 			scope(exit) _spinlock.unlock();
 
 			++w.activeThreads;
+		}
+
+		void stopScanningThreads() shared {
+			auto w = (cast(ScanningList*) &this);
+
+			_spinlock.lock();
+			scope(exit) _spinlock.unlock();
+
+			// need to make the active threads go to -1
+			--w.activeThreads;
+			(cast(Event*)&gcStartedEvent).setIfInitialized();
+		}
+
+		bool waitForGCStart() shared {
+			_spinlock.lock();
+			scope(exit) _spinlock.unlock();
+
+			auto w = (cast(ScanningList*) &this);
+
+			/**
+			* We wait for work to be present in the worklist or the
+			* active threads to be negative (meaning the scanning thread should exit)
+			*/
+			while(!w.hasStarted()) {
+				w.gcStartedEvent.reset();
+				_spinlock.unlock();
+				w.gcStartedEvent.wait();
+				_spinlock.lock();
+			}
+
+			if (w.activeThreads == -1) {
+				// trying to stop GC threads. Wake up anyone else who is waiting.
+				w.gcStartedEvent.setIfInitialized();
+				return false;
+			}
+
+			// this thread now active
+			++w.activeThreads;
+			return true;
 		}
 
 		uint waitForWork(ref WorkItem[MaxRefill] refill) shared {
@@ -183,13 +242,26 @@ private struct ScanningList {
 		}
 	}
 
+	void startGCScan() shared {
+		// note, we don't take the lock here, because there should be no work before a scan starts, and there should be no work when a scan ends.
+		assert(cursor == 0, "starting a GC scan, but still data to scan!");
+		this.threadCache = cast(shared)&.threadCache;
+
+		mainThreadStarted(); // indicate the main thread is participating.
+	}
+
+	auto hasStarted() {
+		return cursor != 0 || activeThreads < 0;
+	}
+
 	auto hasWork() {
-		return cursor != 0 || activeThreads == 0;
+		return cursor != 0 || activeThreads <= 0;
 	}
 
 	void ensureWorklistCapacity(size_t count) {
 		assert(mutexIsHeld(), "mutex not held!");
 		assert(count < uint.max, "Cannot reserve this much capacity!");
+		assert(threadCache !is null, "threadCache is null!");
 
 		if (likely(count <= worklist.length)) {
 			return;
@@ -205,7 +277,6 @@ private struct ScanningList {
 			size = getAllocSize(count * WorkItem.sizeof);
 		}
 
-		import d.gc.tcache;
 		auto ptr = threadCache.realloc(worklist.ptr, size, false);
 		worklist = (cast(WorkItem*) ptr)[0 .. size / WorkItem.sizeof];
 	}
@@ -227,10 +298,10 @@ private struct ScanningList {
 		assert(activeThreads == 0, "Still running threads!");
 
 		// We now done, we can free the worklist.
-		import d.gc.tcache;
-		threadCache.free(cast(void*) worklist.ptr);
+		(cast(ThreadCache*)threadCache).free(cast(void*) worklist.ptr);
 
 		worklist = null;
+		threadCache = null;
 	}
 }
 
@@ -241,10 +312,9 @@ private:
 	ubyte _gcCycle;
 	AddressRange _managedAddressSpace;
 
+	ThreadHandle[] threads;
+
 public:
-	this(ubyte gcCycle) {
-		this._gcCycle = gcCycle;
-	}
 
 	@property
 	AddressRange managedAddressSpace() shared {
@@ -257,37 +327,68 @@ public:
 	}
 
 	private import symgc.thread;
-	void startThreads(ThreadHandle[] threads) {
+	void startThreads(uint nThreads) {
+		if (threads.length != 0) {
+			// threads already running.
+			return;
+		}
+
+		threads = (cast(ThreadHandle*)threadCache.alloc(ThreadHandle.sizeof * nThreads, false, false))[0 .. nThreads];
+
 		work.initialize();
 		static void markThreadEntry(void* ctx) {
 			import d.gc.tcache;
 			threadCache.activateGC(false);
 
+			// Set a flag saying we should not be using our local thread cache.
+			// The only allocations/free we should be doing is to resize the work list.
+			// Note that scanning threads DO NOT have their stack or TLS scanned,
+			// so we can't put any pointers in there that will become garbage.
+			threadCache.setIsScanningThread();
+
 			auto scanner = cast(shared(Scanner)*) ctx;
-			// Deferring becoming active until the thread is fully started
-			// allows the scan to complete if this thread couldn't start (which
-			// can happen in the case of a race between the thread starting and
-			// a paused thread holding a critical lock needed to start
-			// threads).
-			scanner.work.scanThreadStarted();
-			scanner.runMark();
+
+			while(scanner.work.waitForGCStart()) {
+				scanner.runMarkFromScanThread();
+			}
 		}
 
+		// we use a static ThreadRunner because bad things happen if this memory
+		// gets collected before the thread can start.
+		static ThreadRunner!(typeof(&markThreadEntry)) staticRunner;
+
+		// allocate an array to hold the threads.
+		staticRunner.fun = &markThreadEntry;
+		staticRunner.arg = cast(void*) &this;
 		foreach (ref tid; threads) {
-			createGCThread(&tid, &markThreadEntry, cast(void*) &this);
+			createGCThread(&tid, &staticRunner);
 		}
 	}
 
-	void joinThreads(ThreadHandle[] threads) shared {
-		foreach (tid; threads) {
-			joinGCThread(tid);
+	void joinThreads() {
+
+		if (threads.length > 0) {
+			(cast(shared ScanningList*)&work).stopScanningThreads();
+			foreach (tid; threads) {
+				joinGCThread(tid);
+			}
+
+			// free the thread array
+			threadCache.free(threads.ptr);
+			threads = null;
 		}
 
-		work.cleanup();
+		// destroy the work object, it might have OS resources allocated for it.
+		destroy(work);
 	}
 
-	void mark(AddressRange managedSpace) shared {
+	void mark(ubyte gcCycle, AddressRange managedSpace) shared {
+		// set up the address space and the gc cycle. These change every mark phase.
 		this._managedAddressSpace = managedSpace;
+		this._gcCycle = gcCycle;
+
+		// start the GC
+		work.startGCScan();
 
 		// Scan the roots.
 		// TODO: this cast is awful, see if we can fix this.
@@ -295,6 +396,9 @@ public:
 
 		// Now send this thread marking!
 		runMarkFromMainThread();
+
+		// all work is done, clean up the work list.
+		work.cleanup();
 	}
 
 	void addToWorkList(WorkItem item) shared {
@@ -328,18 +432,14 @@ public:
 private:
 
 	void runMarkFromMainThread() shared {
-		auto worker = Worker(&this);
-		import d.gc.thread;
-		threadScan(&worker.scan);
-
-		runMarkImpl(worker);
-	}
-	void runMark() shared {
-		auto worker = Worker(&this);
-		runMarkImpl(worker);
+		runMarkImpl!true();
 	}
 
-	void runMarkImpl(ref Worker worker) shared {
+	void runMarkFromScanThread() shared {
+		runMarkImpl!false();
+	}
+
+	void runMarkImpl(bool mainThread)() shared {
 		/**
 		 * Scan the stack and TLS.
 		 *
@@ -362,25 +462,32 @@ private:
 		// import d.gc.thread;
 		// threadScan(&worker.scan);
 
+		auto worker = Worker(&this);
+
+		static if(mainThread) {
+			// on the main thread, scan the stack and TLS of the thread.
+			worker.setScanParameters();
+			import d.gc.thread;
+			threadScan(&worker.scan);
+		}
+
 		WorkItem[ScanningList.MaxRefill] refill;
-		auto count = work.waitForWork(refill);
-		// had to wait until now to be sure the managed address space is correct
-		worker.managedAddressSpace = managedAddressSpace;
+
 		while (true) {
+			auto count = work.waitForWork(refill);
 			if (count == 0) {
 				// We are done, there is no more work items.
 				return;
 			}
+			// wait until we get work to set the scan parameters (gc cycle and address range).
+			worker.setScanParameters();
 
 			foreach (i; 0 .. count) {
 				worker.scan(refill[i]);
 			}
-			count = work.waitForWork(refill);
 		}
 	}
 }
-
-private:
 
 struct LastDenseSlabCache {
 	AddressRange slab;
@@ -417,7 +524,10 @@ public:
 
 		import d.gc.tcache;
 		this.emap = threadCache.emap;
+	}
 
+	void setScanParameters() {
+		// set up the scan parameters for this batch of scanning.
 		this.managedAddressSpace = scanner.managedAddressSpace;
 		this.gcCycle = scanner.gcCycle;
 	}
@@ -676,6 +786,8 @@ public:
 		return WorkItem(range[0 .. WorkUnit]);
 	}
 }
+
+shared Scanner gScanner;
 
 @"WorkItem" unittest {
 	void* stackPtr;

--- a/source/d/gc/tcache.d
+++ b/source/d/gc/tcache.d
@@ -61,8 +61,11 @@ private:
 	package ThreadState state;
 
 	import symgc.thread;
-	package ThreadHandle self;
-
+	package ThreadId self;
+	version(Windows) {
+		import core.sys.windows.winbase;
+ 		private ThreadHandle suspendHandle = INVALID_HANDLE_VALUE;
+	}
 	version(linux) {
 		import core.sys.posix.sys.types;
 		package pid_t tid;
@@ -93,6 +96,11 @@ private:
 	ubyte nextBinToRecycle;
 
 	ThreadBinState[ThreadBinCount] binStates;
+
+	version(Windows) {
+		import d.sync.waiter;
+		shared(Waiter)* waiter;
+	}
 
 public:
 	bool isInitialized() {
@@ -127,17 +135,53 @@ public:
 
 	auto clearProbationState() => state.clearProbationState();
 
+	version(Windows) {
+		void checkLockWaiting() {
+			// If there is a waiter registered, check if it's busy. If it's busy, then we are going to do a weird busy state switcheroo.
+			if(waiter is null) {
+				return;
+			}
+
+			// If the waiter says that it is in the middle of a wait, then we can't leave the thread suspended. On resuming the world, this thread should be resuspended so the call to resume will be valid.
+			if(waiter.setGCBusy()) {
+				// TODO: maybe it would be nice to be able to get this handle from Thread itself.
+				import core.sys.windows.winbase;
+				import core.sys.windows.winnt;
+				// need to convert thread id into a handle, and then suspend it.
+				suspendHandle = OpenThread(THREAD_ALL_ACCESS, false, this.self);
+				assert(suspendHandle != INVALID_HANDLE_VALUE);
+				ResumeThread(suspendHandle);
+			}
+		}
+
+		void resolveLockWaiting() {
+			if(waiter is null) {
+				return;
+			}
+			import core.sys.windows.winbase;
+			import core.sys.windows.winnt;
+			waiter.clearGCBusy();
+			if (suspendHandle != INVALID_HANDLE_VALUE) {
+				import core.sys.windows.winbase;
+				auto ret = SuspendThread(suspendHandle);
+				assert(ret != 0xFFFFFFFF, "Unable to resuspend thread!");
+				CloseHandle(suspendHandle);
+				suspendHandle = INVALID_HANDLE_VALUE;
+			}
+		}
+	}
+
 	void initialize(shared(ExtentMap)* emap, shared(Base)* base) {
 		this.emap = CachedExtentMap(emap, base);
 
 		// Make sure initialize can be called multiple
 		// times on the same thread cache.
 		if (isInitialized()) {
-			assert(self == currentThreadHandle(), "Invalid current thread handle!");
+			assert(self == currentThreadId(), "Invalid current thread handle!");
 			return;
 		}
 
-		self = currentThreadHandle();
+		self = currentThreadId();
 
 		/**
 		 * You'd think linux would provide a way to get the tid from
@@ -168,6 +212,12 @@ public:
 		// In order to avoid this, we force the thread to
 		// pick an arena at initialization time.
 		reassociateArena(true);
+
+		version(Windows) {
+			// hack to avoid pausing on WaitOnAddress.
+			import d.sync.mutex;
+			this.waiter = Mutex.getWaiterAddress();
+		}
 
 		// Because this may allocate, we do it last.
 		import symgc.rt;

--- a/source/d/sync/mutex.d
+++ b/source/d/sync/mutex.d
@@ -95,6 +95,11 @@ public:
 		word.store(0);
 	}
 
+	version(Windows) static shared(Waiter)* getWaiterAddress() {
+		// hack, return address to the waiter.
+		return &threadData.waiter;
+	}
+
 private:
 	enum Handoff {
 		None,

--- a/source/d/sync/win32/waiter.d
+++ b/source/d/sync/win32/waiter.d
@@ -29,30 +29,53 @@ extern(Windows) {
 
 struct Win32Waiter {
 	Atomic!uint wakeupCount;
+	enum WaitingBit = 1u << 30;
+	enum GCBusyBit = 1u << 31;
+	enum CountMask = WaitingBit - 1;
+
+	// this should be called ONLY with the thread paused.
+	bool setGCBusy() shared {
+		auto b = wakeupCount.fetchAdd(GCBusyBit);
+		return (b & WaitingBit) ? true : false;
+	}
+
+	void clearGCBusy() shared {
+		auto oldval = wakeupCount.fetchSub(GCBusyBit);
+		assert(oldval & GCBusyBit, "GCBusy bit was not set!");
+	}
 
 	bool block( /* TODO: timeout */ ) shared {
 		while (true) {
 			auto c = wakeupCount.load();
-			while (c > 0) {
+			while ((c & CountMask) > 0) {
 				if (wakeupCount.casWeak(c, c - 1)) {
 					// We consumed a wake up.
 					return true;
 				}
 			}
 
-			assert(c == 0, "Failed to consume wake up!");
+			assert((c & CountMask) == 0, "Failed to consume wake up!");
 
+			c += WaitingBit;
+			wakeupCount.fetchAdd(WaitingBit); // let everyone know we are waiting
 			auto err = WaitOnAddress(cast(void*)&wakeupCount, &c, c.sizeof, INFINITE);
 			if (!err) {
 				// TODO: if timeout ever gets implemented, check here.
 				assert(0, "WaitOnAddress operation failed!");
+			}
+			c = wakeupCount.fetchSub(WaitingBit);
+
+			if(c & GCBusyBit) {
+				// GC asked us to pause, wait on the GC event
+				import d.gc.thread;
+				waitForGCBusy();
 			}
 		}
 	}
 
 	void wakeup() shared {
 		auto wuc = wakeupCount.fetchAdd(1);
-		if (wuc == 0) {
+		if ((wuc & CountMask) == 0) {
 			poke();
 		}
 	}

--- a/source/symgc/gcobj.d
+++ b/source/symgc/gcobj.d
@@ -427,6 +427,12 @@ final class SnazzyGC : GC
 			t.tlsGCData = null;
 		}
 	}
+
+	~this() {
+		// clean up any lingering GC threads.
+		import d.gc.scanner;
+		cleanupGCThreads();
+	}
 }
 
 // HELPER FUNCTIONS

--- a/source/symgc/thread.d
+++ b/source/symgc/thread.d
@@ -4,15 +4,17 @@ version(Windows) {
 	import core.sys.windows.winnt : HANDLE;
 	import core.sys.windows.windef : DWORD;
 	import core.sys.windows.winbase;
-	alias currentThreadHandle = GetCurrentThread;
+	alias currentThreadId = GetCurrentThreadId;
 	alias sched_yield = SwitchToThread;
 	alias ThreadHandle = HANDLE;
+	alias ThreadId = DWORD;
 	private enum THREAD_RETURN_VALUE = DWORD(0);
 	extern (C) ThreadHandle _beginthreadex(void*, uint, LPTHREAD_START_ROUTINE, void*, uint, uint*) nothrow @nogc;
 } else version(linux) {
 	import core.sys.posix.pthread : pthread_t, pthread_self;
 	alias ThreadHandle = pthread_t;
-	alias currentThreadHandle = pthread_self;
+	alias ThreadId = pthread_t;
+	alias currentThreadId = pthread_self;
 	public import core.sys.posix.sched: sched_yield;
 	private enum THREAD_RETURN_VALUE = null;
 }

--- a/test/base/test0200.d
+++ b/test/base/test0200.d
@@ -32,7 +32,7 @@ void randomAlloc() {
 	enum CollectCycle = 4 * 1024 * 1024;
 	size_t n = 11400714819323198485;
 	import symgc.thread;
-	n ^= cast(size_t) currentThreadHandle();
+	n ^= cast(size_t) currentThreadId();
 
 	foreach (_; 0 .. 8) {
 		foreach (i; 0 .. CollectCycle) {

--- a/test/base/test0203.d
+++ b/test/base/test0203.d
@@ -59,9 +59,25 @@ void allocateItem(T)() {
 
 extern(C) void pthread_create();
 
+version(WindowsDebug) {
+	extern(Windows) long SegfaultHandler(void* ptr) {
+		// let's see if stdio works
+		import core.stdc.stdio;
+		printf("dead!\n");
+		while(true) {
+			import core.thread;
+			import core.time;
+			Thread.sleep(1.seconds);
+		}
+	}
+
+	extern(Windows) void *AddVectoredExceptionHandler(ulong first, typeof(&SegfaultHandler) Handler);
+}
+
 void main() {
 	// this is needed to engage the pthread hook...
 	version(linux) auto pth = &pthread_create;
+	version(WindowsDebug) assert(AddVectoredExceptionHandler(1, &SegfaultHandler));
 	import d.gc.thread;
 	createProcess();
 	static struct ThreadRunner {


### PR DESCRIPTION
This keeps the scanning threads alive through the complete program, and only closes them when the process is completed (just like regular GC).

This also adds an additional gate on Windows on the `WaitOnAddress` function from our mutex. If a thread is suspended while calling `WaitOnAddress`, it is resumed, but told to hold off continuing if it returns from the system call. This should fix any hangs that occur due to `WaitOnAddress` taking an internal lock. Because all data to be scanned is on the stack at this point, there should be no pointers missed.

In testing, the `WaitOnAddress` function can hang and never return in cases where a suspended thread is inside `WaitOnAddress`.

We still are using spinlock and event for now, but can potentially go back to using our mutex for the scan list on Windows with this fix.

Various changes were needed to implement the scanning thread changes. Notably:

1. Scanning threads no longer scan their stack and TLS. This eliminates the possibility that we could use our GC as C malloc.
2. Scanning threads no longer allocate using their own thread cache. Because we only allocate while holding the scanning mutex, we always use the main thread's threadcache without worry of racing. To ensure this is the case, ThreadCaache now has a boolean `isScanningThread` to assert it never gets used.
3. We no longer allocate the ThreadRunner object to start the scanning threads. This eliminates a problem where the thread runner object is collected before the scanning thread can start. It also simplifies the code quite a bit. When no trampoline is installed, there is no need to allocate. We only need one ThreadRunner anyway.
4. Scanning threads may hang on startup, because some internal thread-related lock is held. For this reason, a scanning thread may not participate in the scan, and therefore we must not set it as an active thread until it's fully started.
5. Because scanning threads don't know when a GC starts or stops, it reads the address range and gc cycle from the global scanner when starting to do work. This is in practice pretty negligible in terms of performance.