### PR TITLE
Call the registration and remove functions even without the pthread h…

### DIFF
--- a/source/d/gc/thread.d
+++ b/source/d/gc/thread.d
@@ -70,9 +70,7 @@ void destroyThread() {
 
 	threadCache.destroyThread();
 
-	version(Symgc_pthread_hook) {
-		gThreadState.remove(&threadCache);
-	}
+	gThreadState.remove(&threadCache);
 }
 
 void preventStopTheWorld() {
@@ -178,10 +176,7 @@ void initThread() {
 	threadCache.initialize(&gExtentMap, &gBase);
 	threadCache.activateGC();
 
-	version(Symgc_pthread_hook) {
-		import d.gc.global;
-		gThreadState.register(&threadCache);
-	}
+	gThreadState.register(&threadCache);
 }
 
 struct ThreadState {
@@ -362,7 +357,9 @@ private:
 			registeredThreadCount++;
 		}
 
-		registeredThreads.insert(tcache);
+		version(Symgc_pthread_hook) {
+			registeredThreads.insert(tcache);
+		}
 	}
 
 	void removeImpl(ThreadCache* tcache) {
@@ -374,7 +371,9 @@ private:
 			registeredThreadCount--;
 		}
 
-		registeredThreads.remove(tcache);
+		version(Symgc_pthread_hook) {
+			registeredThreads.remove(tcache);
+		}
 	}
 
 	version(Symgc_pthread_hook) {


### PR DESCRIPTION
…ook, as we use the count of running threads to make decisions on when to switch arenas. Without this, during a stop-the-world cycle, the arena can be reselected needlessly.