### PR TITLE
Clear metadata bit when freeing a slab explicitly.

### DIFF
--- a/test/druntime/stalemetadata.d
+++ b/test/druntime/stalemetadata.d
@@ -1,0 +1,44 @@
+/+ dub.json:
+   {
+	"name": "stalemetadata",
+	"dependencies": {
+		"symgc" : {
+			"path" : "../../"
+		}
+	},
+	"targetPath": "./bin"
+   }
++/
+//T retval:0
+//T desc: Ensure metadata bit is cleared for next alloc
+
+import symgc.gcobj;
+import core.memory;
+import std.stdio;
+
+extern(C) __gshared rt_options = ["gcopt=gc:sdc"];
+
+struct HasDtor
+{
+	~this() { writeln("dtor");}
+}
+
+struct CorruptDtor
+{
+	size_t[2] val = 0xdeadbeefdeadbeef;
+}
+
+void main()
+{
+	HasDtor*[100] hd;
+	foreach(i, ref p; hd)
+		p = new HasDtor;
+	foreach(i; 0 .. hd.length / 2)
+		GC.free(hd[i * 2]);
+	hd[] = null;
+	foreach(i; 0 .. 20000) {
+		new CorruptDtor;
+		if(++i % 1000 == 0)
+			writeln(i);
+	}
+}


### PR DESCRIPTION
The comment in the code describes what this prevents, but this was causing real segfaults in our internal application.

I confirmed that without this change, the new test fails with a segfault.