### PR TITLE
Add enable/disable functionality support via GC.enable and GC.disable…

### DIFF
--- a/source/d/gc/capi.d
+++ b/source/d/gc/capi.d
@@ -83,6 +83,16 @@ void __sd_gc_tl_activate(bool activated) {
 	threadCache.activateGC(activated);
 }
 
+uint __sd_gc_enable() {
+	import d.gc.collector;
+	return enableAutomaticCollections();
+}
+
+uint __sd_gc_disable() {
+	import d.gc.collector;
+	return disableAutomaticCollections();
+}
+
 PageDescriptor __sd_gc_maybe_get_page_descriptor(void* ptr) {
 	return threadCache.maybeGetPageDescriptor(ptr);
 }

--- a/source/symgc/gcobj.d
+++ b/source/symgc/gcobj.d
@@ -22,6 +22,8 @@ extern(C) nothrow {
 	void __sd_gc_free(void *ptr) @nogc;
 	void __sd_gc_add_roots(void[] range) @nogc;
 	void __sd_gc_remove_roots(void *ptr) @nogc;
+	uint __sd_gc_enable();
+	uint __sd_gc_disable();
 
 	// hook prototypes needed for druntime api (see below)
 	void* __sd_gc_hook_alloc(size_t size, bool containsPointers, bool zeroData);
@@ -33,8 +35,6 @@ extern(C) nothrow {
 	bool __sd_gc_hook_extend_array_used(void* ptr, size_t newUsed, size_t existingUsed);
 	bool __sd_gc_hook_shrink_array_used(void* ptr, size_t newUsed, size_t existingUsed);
 	bool __sd_gc_hook_reserve_array_capacity(void* ptr, size_t request, size_t existingUsed);
-
-	//void __sd_gc_set_scanning_thread_count(uint nThreads) @nogc;
 }
 
 enum TYPEINFO_IN_BLOCK = cast(void*)1;
@@ -130,8 +130,7 @@ final class SnazzyGC : GC
 {
 	void enable()
 	{
-		// TODO: implement when hook works
-		//__sd_gc_activate(true);
+		__sd_gc_enable();
 	}
 
 	/**
@@ -139,8 +138,7 @@ final class SnazzyGC : GC
 	 */
 	void disable()
 	{
-		// TODO: implement when hook works
-		//__sd_gc_activate(false);
+		__sd_gc_disable();
 	}
 
 	/**

--- a/test/druntime/enabledisable.d
+++ b/test/druntime/enabledisable.d
@@ -1,0 +1,62 @@
+/+ dub.json:
+   {
+	   "name": "enabledisable",
+	   "dependencies": {
+		   "symgc" : {
+			   "path" : "../../"
+		   }
+	   },
+	   "targetPath": "./bin"
+   }
++/
+//T retval:0
+//T desc: Test enabling and disabling the GC
+import symgc.gcobj;
+
+extern(C) __gshared rt_options = ["gcopt=gc:sdc"];
+
+struct S {
+	__gshared uint dtors;
+
+	ubyte[1024] data;
+	~this() {
+		++dtors;
+	}
+}
+
+void main()
+{
+	void allocS(size_t count) {
+		foreach(i; 0 .. count) {
+			new S;
+		}
+	}
+
+	import core.memory;
+	GC.disable();
+	allocS(100_000);
+	// no dtors should have run (no collections)
+	assert(S.dtors == 0);
+
+	// test reentrancy
+	GC.disable();
+	allocS(10_000);
+	assert(S.dtors == 0);
+	GC.enable();
+	allocS(10_000);
+	assert(S.dtors == 0);
+
+	// test enabling and finally running a cycle
+	GC.enable();
+	allocS(10_000);
+	assert(S.dtors > 0);
+
+	// test disabling and running a GC cycle manually
+	GC.disable();
+	S.dtors = 0;
+	allocS(100_000);
+	assert(S.dtors == 0);
+	GC.collect();
+	assert(S.dtors > 0);
+	GC.enable();
+}


### PR DESCRIPTION
…. This adds a new reentrant counter instead of just disabling the thread local allocations (which has no equivalent druntime interface).