### PR TITLE
Fix get array slice

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,13 +17,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {os: ubuntu-latest,     dc: dmd-2.111.0}
+          - {os: ubuntu-latest,     dc: dmd-2.112.0}
           - {os: ubuntu-latest,     dc: dmd-master}
           - {os: ubuntu-latest,     dc: ldc-1.41.0}
           - {os: ubuntu-latest,     dc: ldc-beta}
           - {os: ubuntu-24.04-arm,  dc: ldc-1.41.0}
           - {os: ubuntu-24.04-arm,  dc: ldc-beta}
           - {os: windows-latest,    dc: dmd-master}
+          - {os: windows-latest,    dc: dmd-2.112.0}
           - {os: windows-latest,    dc: ldc-beta}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15

--- a/source/symgc/gcobj.d
+++ b/source/symgc/gcobj.d
@@ -555,7 +555,8 @@ size_t hook_getArrayCapacity(void[] slice) {
 
 pragma(mangle, "__sd_gc_hook_get_allocation_slice")
 void[] hook_getAllocationSlice(const void* ptr) {
-	return threadCache.getAllocationSlice(ptr);
+	auto slice = threadCache.getAllocationSlice(ptr);
+	return slice[0 .. $ > 0 ? $-1 : 0]; // remove padding byte
 }
 
 pragma(mangle, "__sd_gc_hook_shrink_array_used")

--- a/test/druntime/shrinkfit.d
+++ b/test/druntime/shrinkfit.d
@@ -1,0 +1,27 @@
+/+ dub.json:
+   {
+	   "name": "shrinkfit",
+		"dependencies": {
+			"symgc" : {
+				"path" : "../../"
+			}
+		},
+		"targetPath": "./bin"
+   }
++/
+//T retval:0
+//T desc: Ensure assumeSafeAppend works as expected
+
+import symgc.gcobj;
+
+extern(C) __gshared rt_options = ["gcopt=gc:sdc"];
+
+void main() {
+	auto arr = [1, 2, 3, 4];
+	auto origcap = arr.capacity;
+	assert(origcap != 0);
+	arr = arr[0 .. 1];
+	assert(arr.capacity == 0);
+	arr.assumeSafeAppend;
+	assert(arr.capacity == origcap);
+}


### PR DESCRIPTION
Prior to this, the slice fetched is off-by-one, since an array allocation always includes a trailing byte to prevent cross-block pointers.

This resulted in assumeSafeAppend always failing when it should pass, and resulting appending reallocating the array.

With 2.112.0 release, this also was triggering an assert in the new templated array hooks.