### PR TITLE
Honor GC.free no-op cases used by QuickBite

### DIFF
--- a/source/d/gc/tcache.d
+++ b/source/d/gc/tcache.d
@@ -321,7 +321,28 @@ public:
 			return;
 		}
 
-		auto pd = getPageDescriptor(ptr);
+		// GC.free must take no action when called from a finalizer. The page
+		// collector invokes finalizers while holding its page-filler mutex, so
+		// returning a slot through a thread bin here can also deadlock by
+		// re-entering the same page filler.
+		if (inFinalizer) {
+			return;
+		}
+
+		// GC.free also ignores pointers not owned by this collector and pointers
+		// into the interior of an allocation.
+		auto pd = maybeGetPageDescriptor(ptr);
+		if (pd.extent is null) {
+			return;
+		}
+		if (pd.isSlab()) {
+			auto si = SlabAllocInfo(pd, ptr);
+			if (ptr !is si.address) {
+				return;
+			}
+		} else if (ptr !is pd.extent.address) {
+			return;
+		}
 		free(pd, ptr);
 	}
 

--- a/source/d/gc/tcache.d
+++ b/source/d/gc/tcache.d
@@ -325,22 +325,13 @@ public:
 		// collector invokes finalizers while holding its page-filler mutex, so
 		// returning a slot through a thread bin here can also deadlock by
 		// re-entering the same page filler.
-		if (inFinalizer) {
+		if (unlikely(inFinalizer)) {
 			return;
 		}
 
-		// GC.free also ignores pointers not owned by this collector and pointers
-		// into the interior of an allocation.
+		// GC.free also ignores pointers not owned by this collector.
 		auto pd = maybeGetPageDescriptor(ptr);
-		if (pd.extent is null) {
-			return;
-		}
-		if (pd.isSlab()) {
-			auto si = SlabAllocInfo(pd, ptr);
-			if (ptr !is si.address) {
-				return;
-			}
-		} else if (ptr !is pd.extent.address) {
+		if (unlikely(pd.extent is null)) {
 			return;
 		}
 		free(pd, ptr);

--- a/test/base/test0204.d
+++ b/test/base/test0204.d
@@ -1,0 +1,39 @@
+/+ dub.json:
+   {
+	   "name": "test0204",
+	   "dependencies": {
+		   "dmd:root": "2.112.0",
+		   "symgc" : {
+			   "path" : "../../",
+		   }
+	   },
+	   "subConfigurations" : {
+		   "symgc": "integration"
+	   },
+	   "targetPath": "./bin"
+   }
++/
+//T retval:0
+//T desc:DMD can xfree an OutBuffer while using SymGC
+
+import dmd.common.outbuffer : OutBuffer;
+import dmd.root.rmem : mem;
+import symgc.gcobj;
+
+extern(C) __gshared rt_options = ["gcopt=gc:sdc"];
+
+void main()
+{
+	// Quickbite has already initialized the collector through DMD allocations
+	// before lambda comparison reaches the OutBuffer xfree below.
+	mem.xmalloc(1);
+
+	// OutBuffer allocates with C realloc, but mem.xfree delegates to GC.free
+	// when DMD is embedded with its GC enabled, as it is in Quickbite. GC.free
+	// must ignore memory not allocated by the active collector:
+	// https://dlang.org/phobos/core_memory.html#.GC.free
+	OutBuffer buffer;
+	buffer.writestring("Quickbite");
+	auto serialization = buffer.extractSlice();
+	mem.xfree(serialization.ptr);
+}


### PR DESCRIPTION
Depends on #49; merge #49 first so the Windows/DMD-master baseline is green.

Honor the `GC.free` no-op cases required by QuickBite:

- Ignore calls made while the collector is running finalizers. Finalizers run while the page-filler mutex is held, and returning a slot through a full thread bin can otherwise re-enter the page filler and deadlock.
- Ignore pointers not owned by SymGC. DMD's `OutBuffer` allocates with C `realloc`, but `mem.xfree` delegates to `GC.free` when DMD is embedded with its GC enabled.

Both exceptional branches are marked `unlikely`. Interior-pointer validation is intentionally left for a separate change.

`test0204` covers the unmanaged-pointer regression. The complete QuickBite cerealed interpreter workload covers the combined behavior and completes all 156 tests; removing the finalizer guard causes that workload to stall.

Checks:

- `dub test`: 29 modules passed
- `cd test && dub -- base/test0204.d`: passed
- `DFLAGS=-preview=dip1000 dub build`: passed
- QuickBite `./bin/bench.sh -w 0 -r 1 -b interpreter --dub cerealed`: 156/156 passed

Authored with Codex.
