### PR TITLE
Fix Windows DMD-master finalizer test

### DIFF
--- a/test/druntime/finalizer.d
+++ b/test/druntime/finalizer.d
@@ -36,11 +36,9 @@ void prepareStack() {
 	clobber();
 }
 
-// TODO: figure out why 10_001 are needed to make this work instead of 10_000.
-enum objCount = 10_001;
+enum objCount = 10_000;
 
-shared static ~this() {
-	// make sure we clobber the stack
+void collectFinalizers() {
 	prepareStack();
 	import core.memory;
 	GC.collect();
@@ -48,9 +46,17 @@ shared static ~this() {
 }
 
 void main() {
-	foreach(i; 0 .. objCount)
-	{
-		new Finalized();
-	}
+	// Allocate on a worker so conservative stack scanning cannot retain the
+	// final allocation through a stale pointer in main's stack frame.
+	import core.thread : Thread;
+	auto allocator = new Thread({
+		foreach(i; 0 .. objCount)
+		{
+			new Finalized();
+		}
+		__sd_gc_tl_flush_cache();
+	});
+	allocator.start();
+	allocator.join();
+	collectFinalizers();
 }
-


### PR DESCRIPTION
Fix the Windows/DMD-master CI failure in the existing finalizer integration test.

The test allocated finalizable objects on the same stack later scanned conservatively, so stale pointers could retain the last object and make the exact-count assertion compiler-dependent. This surfaced after DMD commit [`e67a29fe`](https://github.com/dlang/dmd/commit/e67a29fe2570b4d4840a1d63cb13eb37d6f35487), which fixed issue #22054 by refreshing the Windows stack bottom from the TEB before scanning. Allocations now happen on a worker thread; after it exits, its retired stack cannot retain an object accidentally. The test can therefore assert exactly 10,000 finalizations without the unexplained 10,001 workaround.

This failure was reproduced on a fork branch whose tree is identical to `master`: https://github.com/atilaneves/symgc/actions/runs/31576703076/job/94050331661

Checks:

- `cd test && dub -- druntime/finalizer.d`: passed
- Full CI matrix: 9/9 passed, including Windows/DMD-master

PR #48 depends on this PR and must merge second. It contains only the QuickBite/SymGC fix.
