### PR TITLE
bugfix for cross-reservation commits on Windows

### DIFF
--- a/source/d/gc/memmap.d
+++ b/source/d/gc/memmap.d
@@ -102,6 +102,156 @@ void pages_commit(void* addr, size_t size) {
 	// linux does not need explicit commit
 }
 
+version(Windows) {
+	/**
+	 * How far the reservation containing addr extends, capped at maxLen.
+	 *
+	 * MEMORY_BASIC_INFORMATION describes a run of pages in the same state
+	 * rather than a whole reservation, so walk forward until AllocationBase
+	 * changes. If the range does not cross a boundary this returns maxLen on
+	 * the first iteration.
+	 */
+	size_t reservationExtent(void* addr, size_t maxLen) nothrow @nogc {
+		MEMORY_BASIC_INFORMATION mbi;
+		if (VirtualQuery(addr, &mbi, mbi.sizeof) == 0) {
+			// Cannot tell; let the caller attempt the range unsplit.
+			return maxLen;
+		}
+
+		auto allocBase = mbi.AllocationBase;
+		auto start = cast(ubyte*) addr;
+		auto end = start + maxLen;
+
+		while (true) {
+			auto regionEnd = cast(ubyte*) mbi.BaseAddress + mbi.RegionSize;
+			if (regionEnd >= end) {
+				return maxLen;
+			}
+
+			if (VirtualQuery(regionEnd, &mbi, mbi.sizeof) == 0
+				    || mbi.AllocationBase !is allocBase) {
+				return regionEnd - start;
+			}
+		}
+	}
+
+	enum VmOp {
+		commit,
+		decommit,
+		reset,
+	}
+
+	bool applyOp(VmOp op, void* addr, size_t size) nothrow @nogc {
+		final switch (op) {
+			case VmOp.commit:
+				return VirtualAlloc(addr, size, MEM_COMMIT, PAGE_READWRITE)
+					!is null;
+
+			case VmOp.decommit:
+				return VirtualFree(addr, size, MEM_DECOMMIT) != 0;
+
+			case VmOp.reset:
+				return VirtualAlloc(addr, size, MEM_RESET, PAGE_READWRITE)
+					!is null;
+		}
+	}
+
+	/**
+	 * Windows rejects a commit, decommit or reset that crosses from one
+	 * reservation into another, but the region allocator merges adjacent
+	 * regions without recording which reservation each came from, so a range
+	 * handed down here can legitimately straddle two. Rather than forbid that
+	 * merge -- coalescing neighbours is worth keeping -- the OS constraint is
+	 * handled where it belongs, by splitting the operation on the boundary.
+	 *
+	 * Callers try the whole range first, so this only runs in the rare case
+	 * where that failed and costs nothing in the common one.
+	 */
+	bool applyPerReservation(VmOp op, void* addr, size_t size) nothrow @nogc {
+		auto p = cast(ubyte*) addr;
+		auto end = p + size;
+
+		while (p < end) {
+			auto chunk = reservationExtent(p, end - p);
+			if (chunk == 0 || !applyOp(op, p, chunk)) {
+				return false;
+			}
+
+			p += chunk;
+		}
+
+		return true;
+	}
+
+	/// The error code is the only way to tell these failures apart, and it was
+	/// previously discarded.
+	void reportVmFailure(const(char)* op, void* addr, size_t size) nothrow @nogc {
+		auto err = GetLastError();
+
+		import core.stdc.stdio;
+		fprintf(stderr, "symgc: %s failed for [%p, %p) (%llu bytes), error %u\n",
+		        op, addr, cast(ubyte*) addr + size, cast(ulong) size, err);
+		fflush(stderr);
+	}
+}
+
+version(Windows)
+unittest {
+	// Two adjacent but separate reservations, which is what the region
+	// allocator can produce by merging neighbours: take a span, release it,
+	// then re-reserve each half on its own.
+	enum Half = 4 * 1024 * 1024;
+
+	auto probe = VirtualAlloc(null, 2 * Half, MEM_RESERVE, PAGE_READWRITE);
+	assert(probe !is null, "Could not reserve probe span!");
+	VirtualFree(probe, 0, MEM_RELEASE);
+
+	auto a = VirtualAlloc(probe, Half, MEM_RESERVE, PAGE_READWRITE);
+	if (a is null) {
+		// Something else claimed the range in between; nothing to test.
+		return;
+	}
+
+	auto b = VirtualAlloc(cast(ubyte*) probe + Half, Half, MEM_RESERVE,
+	                      PAGE_READWRITE);
+	if (b is null) {
+		VirtualFree(a, 0, MEM_RELEASE);
+		return;
+	}
+
+	scope(exit) {
+		VirtualFree(a, 0, MEM_RELEASE);
+		VirtualFree(b, 0, MEM_RELEASE);
+	}
+
+	// Straddle the boundary: start halfway through the first reservation and
+	// run halfway into the second.
+	auto straddle = cast(ubyte*) a + Half / 2;
+
+	// A single call cannot do this. MEM_COMMIT and MEM_RESET report
+	// ERROR_INVALID_ADDRESS, MEM_DECOMMIT reports ERROR_INVALID_PARAMETER.
+	assert(VirtualAlloc(straddle, Half, MEM_COMMIT, PAGE_READWRITE) is null,
+	       "MEM_COMMIT across a reservation boundary should fail!");
+	assert(applyPerReservation(VmOp.commit, straddle, Half),
+	       "Split commit should succeed!");
+
+	assert(VirtualFree(straddle, Half, MEM_DECOMMIT) == 0,
+	       "MEM_DECOMMIT across a reservation boundary should fail!");
+	assert(applyPerReservation(VmOp.decommit, straddle, Half),
+	       "Split decommit should succeed!");
+
+	assert(applyPerReservation(VmOp.commit, straddle, Half),
+	       "Split recommit should succeed!");
+	assert(VirtualAlloc(straddle, Half, MEM_RESET, PAGE_READWRITE) is null,
+	       "MEM_RESET across a reservation boundary should fail!");
+	assert(applyPerReservation(VmOp.reset, straddle, Half),
+	       "Split reset should succeed!");
+
+	// A range inside one reservation must still go through unsplit.
+	assert(applyPerReservation(VmOp.commit, a, Half / 2),
+	       "Commit within a single reservation should succeed!");
+}
+
 void pages_unmap(void* addr, size_t size) {
 	version(linux) {
 		auto ret = munmap(addr, size);

--- a/source/d/gc/memmap.d
+++ b/source/d/gc/memmap.d
@@ -205,7 +205,7 @@ version(Windows) {
 }
 
 version(Windows)
-unittest {
+@"applyPerReservation" unittest {
 	// Two adjacent but separate reservations, which is what the region
 	// allocator can produce by merging neighbours: take a span, release it,
 	// then re-reserve each half on its own.

--- a/source/d/gc/memmap.d
+++ b/source/d/gc/memmap.d
@@ -178,15 +178,16 @@ version(Windows) {
 	 */
 	bool applyPerReservation(VmOp op, void* addr, size_t size) nothrow @nogc {
 		auto p = cast(ubyte*) addr;
-		auto end = p + size;
+		auto left = size;
 
-		while (p < end) {
-			auto chunk = reservationExtent(p, end - p);
+		while (left > 0) {
+			auto chunk = reservationExtent(p, left);
 			if (chunk == 0 || !applyOp(op, p, chunk)) {
 				return false;
 			}
 
 			p += chunk;
+			left -= chunk;
 		}
 
 		return true;

--- a/source/d/gc/memmap.d
+++ b/source/d/gc/memmap.d
@@ -96,8 +96,17 @@ void pages_commit(void* addr, size_t size) {
 			return;
 		}
 		auto ret = VirtualAlloc(addr, size, MEM_COMMIT, PAGE_READWRITE);
-		assert(ret !is null, "Could not commit memory!");
-		assert(ret is addr, "MEM_COMMIT moved alloction!");
+		if (ret !is null) {
+			assert(ret is addr, "MEM_COMMIT moved alloction!");
+			return;
+		}
+
+		if (applyPerReservation(VmOp.commit, addr, size)) {
+			return;
+		}
+
+		reportVmFailure("MEM_COMMIT", addr, size);
+		assert(false, "Could not commit memory!");
 	}
 	// linux does not need explicit commit
 }
@@ -268,7 +277,30 @@ void pages_purge(void* addr, size_t size) {
 		auto ret = madvise(addr, size, MADV_DONTNEED);
 		assert(ret == 0, "madvise failed!");
 	} else version(Windows) {
-		VirtualFree(addr, size, MEM_DECOMMIT);
+		/**
+		 * This used to discard the result. A decommit that straddles two
+		 * reservations fails with ERROR_INVALID_PARAMETER and leaves the pages
+		 * committed, so the failure is invisible while commit charge keeps
+		 * climbing -- which eventually shows up as a commit failure somewhere
+		 * unrelated. Report it rather than assert, so diagnosing this cannot
+		 * itself take a process down.
+		 */
+		if (VirtualFree(addr, size, MEM_DECOMMIT)) {
+			return;
+		}
+
+		if (applyPerReservation(VmOp.decommit, addr, size)) {
+			return;
+		}
+
+		/**
+		 * This used to discard the result entirely. A decommit that fails
+		 * leaves the pages committed, so the failure is invisible while commit
+		 * charge keeps climbing, and it eventually surfaces as a commit
+		 * failure somewhere unrelated. Report it rather than assert, so
+		 * diagnosing this cannot itself take a process down.
+		 */
+		reportVmFailure("MEM_DECOMMIT", addr, size);
 	}
 }
 
@@ -277,7 +309,17 @@ void pages_purge_lazy(void* addr, size_t size) {
 		auto ret = madvise(addr, size, MADV_FREE);
 		assert(ret == 0, "madvise failed!");
 	} else version (Windows) {
-		VirtualAlloc(addr, size, MEM_RESET, PAGE_READWRITE);
+		// MEM_RESET is rejected across a reservation boundary too, with
+		// ERROR_INVALID_ADDRESS. Same silent-failure risk as pages_purge.
+		if (VirtualAlloc(addr, size, MEM_RESET, PAGE_READWRITE) !is null) {
+			return;
+		}
+
+		if (applyPerReservation(VmOp.reset, addr, size)) {
+			return;
+		}
+
+		reportVmFailure("MEM_RESET", addr, size);
 	}
 }
 

--- a/test/druntime/wincommit.d
+++ b/test/druntime/wincommit.d
@@ -1,0 +1,71 @@
+/+ dub.json:
+   {
+	   "name": "wincommit",
+	   "dependencies": {
+		   "symgc" : {
+			   "path" : "../../"
+		   }
+	   },
+	   "targetPath": "./bin"
+   }
++/
+//T retval:0
+//T desc: Test to confirm Windows memory commit across multiple reservations works
+//T platform:win64
+import symgc.gcobj;
+
+extern(C) __gshared rt_options = ["gcopt=gc:sdc"];
+
+import core.sys.windows.winbase;
+import core.sys.windows.winnt;
+
+import core.memory;
+
+void main()
+{
+    // disable any GC cycles for this test.
+    GC.disable();
+    scope(exit) GC.enable();
+
+    // constants for sizing
+    enum size_t gb = 1024*1024*1024;
+    enum size_t blockSize = 1024*1024*2;
+
+    /* The goal here is to set up an environment where a 2GB continuous space
+     * will be allocated into the scannable region. This will be allocated 1GB
+     * at a time. We can't allocate 2GB directly, because that will be one
+     * region and we won't get the overlap error. We can't leave this space
+     * open because the GC sometimes allocates small bits (metadata, radix
+     * tree leaves, etc) which would break up the space. To prevent this, we
+     * do the following:
+     *
+     * 1. Find the end of the allocated space. This is where new allocations will occur. We increment 1 block (2MB) at a time, as this is the granularity of symgc allocations
+     * 2. Put up a blocker allocation directly with the OS. This prevents other allocations (such as other regions, or metadata blocks) from breaking up a 2GB address space.
+     * 3. We start with 2GB of blocker. We want to make sure the OS didn't hand out some of this speace elsewhere (in all tests I've performed this is never an issue)
+     * 4. We free that 2GB and just block the second GB of space. This gives a 1GB hole to allocate into, but blocks any small allocations after that.
+     * 5. Allocate a 1GB block. This won't fit into the existing memory space, so it will ask for another 1GB from the OS. It should go directly into the hole.
+     * 6. Remove the blocker, and allocate a second 1GB block. It should go directly after the first 1gb block.
+     * 7. Free both blocks, which the GC then combines into one large piece of unused address space.
+     * 8. Allocate 1.5G block. This should span the two address spaces, and cause the overlapping commit.
+     */
+    void *p1 = GC.malloc(gb/2);
+    GC.free(p1); // don't actually need to keep it around, we just needed a valid address in the heap.
+    void *target = p1 + gb/2;
+    void *blocker = null;
+    while(!blocker) {
+        blocker = VirtualAlloc(target, 2*gb, MEM_RESERVE, PAGE_READWRITE);
+        target += blockSize;
+    }
+
+    assert(VirtualFree(blocker, 0, MEM_RELEASE));
+    blocker = VirtualAlloc(blocker + gb, gb, MEM_RESERVE, PAGE_READWRITE);
+    assert(blocker);
+    void *p2 = GC.malloc(gb);
+    assert(p2 + gb == blocker);
+    assert(VirtualFree(blocker, 0, MEM_RELEASE));
+    void *p3 = GC.malloc(gb);
+    assert(p2 + gb == p3);
+    GC.free(p2);
+    GC.free(p3);
+	GC.malloc(gb * 3 / 2);
+}


### PR DESCRIPTION
The bug: symgc reserves address space a gigabyte at a time, and RegionAllocator.registerRegion merges adjacent regions purely on address adjacency, without recording which reservation each came from. A Region can therefore span two, and the huge allocation paths in page.d then issue one pages_commit across the whole thing. Windows refuses a commit that crosses a reservation boundary, so symgc aborted with "Could not commit memory!".

  * applyPerReservation() and its helpers, which split a commit, decommit or reset on reservation boundaries.
  * The three call sites. Each tries the whole range first, so the split path only runs when that fails and costs nothing in the common case.
  * pages_purge and pages_purge_lazy now check their result. They discarded it before, so a failed decommit silently left the pages committed and the process' commit charge climbing.
  * GetLastError() in the failure message. 487 (boundary crossing) and 1455 (genuine commit-limit exhaustion) used to produce an identical assert. We now show the result code.
  * A unittest that builds two adjacent-but-separate reservations, confirms a single call across them is refused, and confirms the split path succeeds. Deterministic, and verified to fail if the fix is removed.


AI generated. I have trimmed back a bunch of tests and guards that were used to find the problem.