### PR TITLE
Turn GC.free into a noop when called from a finalizer.

### DIFF
--- a/source/symgc/gcobj.d
+++ b/source/symgc/gcobj.d
@@ -260,6 +260,13 @@ final class SnazzyGC : GC
 	 */
 	void free(void* p) nothrow @nogc
 	{
+		if (inFinalizer) {
+			// In order to avoid a double free when GC.free is called on an
+			// allocation that is about to be collected, we turn GC.free into
+			// a no-op when it is called from a finalizer.
+			return;
+		}
+
 		// Note: p is not supposed to be freed if it is an interior pointer,
 		// but it is freed in SDC in this case.
 		__sd_gc_free(p);


### PR DESCRIPTION
We want to keep the number of pages hit on the fast allocation/deallocation path to be kept to a minimum for 2 reasons. First, each one can lead to a TLB or cache miss, costing hundred of cycles, and second, because each time it doesn't, it means an entry in the cache or the TLB was kept for the GC instead of the application.

While this cost would be unacceptable in the core function, it is an unfortunate fact of life that GC.free require this semantic and that using the GC object instead of calling into the GC directly already causes 3 pages hits, and double the time needed to allocate deallocate.

Maybe one day we'll be able to kill this interface and give it the glorious death it deserves, but, in the meantime, we make sure to contains the peformance hit necessary for this "feature" to the GC interface.